### PR TITLE
Update README clone instructions to fork repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This repository allows you to automatically set up Google Cloud resources using 
 ## Getting Started
 1. Clone the repository:
     ```sh
-    git clone https://github.com/DeNA/dify-google-cloud-terraform.git
+    git clone https://github.com/Kenkooo/dify-google-cloud-terraform.git
     ```
 
 2. Initialize Terraform:

--- a/README_ja.md
+++ b/README_ja.md
@@ -37,7 +37,7 @@
 ## 始め方
 1. リポジトリをクローン:
     ```sh
-    git clone https://github.com/DeNA/dify-google-cloud-terraform.git
+    git clone https://github.com/Kenkooo/dify-google-cloud-terraform.git
     ```
 
 2. Terraformを初期化:


### PR DESCRIPTION
## Summary
- point the README clone instructions to this repository instead of the upstream fork source
- update both English and Japanese READMEs so users copy the correct git clone URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcb8033cdc8321be74682c6134f294