### PR TITLE
Add workspace-specific naming and labels

### DIFF
--- a/terraform/modules/cloudrun/variables.tf
+++ b/terraform/modules/cloudrun/variables.tf
@@ -6,6 +6,14 @@ variable "region" {
   type = string
 }
 
+variable "workspace_suffix" {
+  type = string
+}
+
+variable "workspace_labels" {
+  type = map(string)
+}
+
 variable "dify_version" {
   type = string
 }

--- a/terraform/modules/cloudsql/variables.tf
+++ b/terraform/modules/cloudsql/variables.tf
@@ -6,6 +6,14 @@ variable "region" {
   type = string
 }
 
+variable "workspace_suffix" {
+  type = string
+}
+
+variable "workspace_labels" {
+  type = map(string)
+}
+
 variable "db_username" {
   type = string
 }

--- a/terraform/modules/filestore/main.tf
+++ b/terraform/modules/filestore/main.tf
@@ -1,5 +1,13 @@
+locals {
+  filestore_name = regexreplace(
+    substr("dify-${var.workspace_suffix}-filestore", 0, min(63, length("dify-${var.workspace_suffix}-filestore"))),
+    "-+$",
+    ""
+  )
+}
+
 resource "google_filestore_instance" "default" {
-  name     = "dify-filestore"
+  name     = local.filestore_name
   location = "${var.region}-b"
   tier     = "BASIC_HDD"
 
@@ -12,4 +20,6 @@ resource "google_filestore_instance" "default" {
     network = var.vpc_network_name
     modes   = ["MODE_IPV4"]
   }
+
+  labels = var.workspace_labels
 }

--- a/terraform/modules/filestore/variables.tf
+++ b/terraform/modules/filestore/variables.tf
@@ -5,3 +5,11 @@ variable "region" {
 variable "vpc_network_name" {
   type = string
 }
+
+variable "workspace_suffix" {
+  type = string
+}
+
+variable "workspace_labels" {
+  type = map(string)
+}

--- a/terraform/modules/network/variables.tf
+++ b/terraform/modules/network/variables.tf
@@ -5,3 +5,7 @@ variable "project_id" {
 variable "region" {
   type = string
 }
+
+variable "workspace_suffix" {
+  type = string
+}

--- a/terraform/modules/redis/main.tf
+++ b/terraform/modules/redis/main.tf
@@ -1,11 +1,21 @@
+locals {
+  redis_instance_name = regexreplace(
+    substr("dify-${var.workspace_suffix}-redis", 0, min(63, length("dify-${var.workspace_suffix}-redis"))),
+    "-+$",
+    ""
+  )
+}
+
 resource "google_redis_instance" "dify_redis" {
-  name              = "dify-redis"
+  name              = local.redis_instance_name
   tier              = "STANDARD_HA"
   memory_size_gb    = 1
   region            = var.region
   project           = var.project_id
   redis_version     = "REDIS_6_X"
   reserved_ip_range = "10.0.1.0/29"
+
+  labels = var.workspace_labels
 
   authorized_network = var.vpc_network_name
 }

--- a/terraform/modules/redis/variables.tf
+++ b/terraform/modules/redis/variables.tf
@@ -9,3 +9,11 @@ variable "region" {
 variable "vpc_network_name" {
   type = string
 }
+
+variable "workspace_suffix" {
+  type = string
+}
+
+variable "workspace_labels" {
+  type = map(string)
+}

--- a/terraform/modules/registry/main.tf
+++ b/terraform/modules/registry/main.tf
@@ -4,6 +4,7 @@ resource "google_artifact_registry_repository" "nginx_repo" {
   location      = var.region
   repository_id = var.nginx_repository_id
   format        = "DOCKER"
+  labels        = var.workspace_labels
 }
 
 resource "google_artifact_registry_repository" "api_repo" {
@@ -12,6 +13,7 @@ resource "google_artifact_registry_repository" "api_repo" {
   location      = var.region
   repository_id = var.api_repository_id
   format        = "DOCKER"
+  labels        = var.workspace_labels
 }
 
 resource "google_artifact_registry_repository" "web_repo" {
@@ -21,6 +23,7 @@ resource "google_artifact_registry_repository" "web_repo" {
   repository_id = var.web_repository_id
   format        = "DOCKER"
   mode          = "REMOTE_REPOSITORY"
+  labels        = var.workspace_labels
   remote_repository_config {
     docker_repository {
       public_repository = "DOCKER_HUB"
@@ -35,6 +38,7 @@ resource "google_artifact_registry_repository" "sandbox_repo" {
   repository_id = var.sandbox_repository_id
   format        = "DOCKER"
   mode          = "REMOTE_REPOSITORY"
+  labels        = var.workspace_labels
   remote_repository_config {
     docker_repository {
       public_repository = "DOCKER_HUB"
@@ -49,6 +53,7 @@ resource "google_artifact_registry_repository" "plugin_daemon_repo" {
   repository_id = var.plugin_daemon_repository_id
   format        = "DOCKER"
   mode          = "REMOTE_REPOSITORY"
+  labels        = var.workspace_labels
   remote_repository_config {
     docker_repository {
       public_repository = "DOCKER_HUB"

--- a/terraform/modules/registry/variables.tf
+++ b/terraform/modules/registry/variables.tf
@@ -6,6 +6,10 @@ variable "region" {
   type = string
 }
 
+variable "workspace_labels" {
+  type = map(string)
+}
+
 variable "nginx_repository_id" {
   type = string
 }

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -1,16 +1,34 @@
+locals {
+  bucket_base      = lower("${var.project_id}-${var.google_storage_bucket_name}-${var.workspace_suffix}")
+  bucket_sanitized = regexreplace(local.bucket_base, "[^a-z0-9-]", "-")
+  bucket_compact   = regexreplace(local.bucket_sanitized, "-{2,}", "-")
+  bucket_value     = trim(local.bucket_compact, "-") != "" ? trim(local.bucket_compact, "-") : lower("${var.project_id}-${var.workspace_suffix}")
+  bucket_name      = regexreplace(
+    substr(local.bucket_value, 0, min(63, length(local.bucket_value))),
+    "-+$",
+    ""
+  )
+  service_account_id = regexreplace(
+    substr("dify-${var.workspace_suffix}-storage-sa", 0, min(30, length("dify-${var.workspace_suffix}-storage-sa"))),
+    "-+$",
+    ""
+  )
+}
+
 resource "google_storage_bucket" "dify_storage" {
   force_destroy               = false
   location                    = upper(var.region)
-  name                        = "${var.project_id}_${var.google_storage_bucket_name}"
+  name                        = local.bucket_name
   project                     = var.project_id
   public_access_prevention    = "enforced"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = true
+  labels                      = var.workspace_labels
 }
 
 resource "google_service_account" "storage_admin" {
-  account_id   = "storage-admin-for-dify"
-  display_name = "Storage Admin Service Account"
+  account_id   = local.service_account_id
+  display_name = "Storage Admin Service Account (${var.workspace_suffix})"
 }
 
 resource "google_storage_bucket_iam_member" "storage_admin" {

--- a/terraform/modules/storage/variables.tf
+++ b/terraform/modules/storage/variables.tf
@@ -9,3 +9,11 @@ variable "region" {
 variable "google_storage_bucket_name" {
   type = string
 }
+
+variable "workspace_suffix" {
+  type = string
+}
+
+variable "workspace_labels" {
+  type = map(string)
+}


### PR DESCRIPTION
## Summary
- normalize workspace names once in the root module and pass the suffix/labels to child modules
- append the workspace suffix to resource identifiers to avoid cross-workspace naming collisions
- tag supported Google Cloud resources with a workspace label for easier filtering

## Testing
- terraform fmt -recursive *(fails: terraform command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc92fda0c83219aa5d47fd33f982c