### PR TITLE
Normalize Terraform resource identifiers without regex dependencies

### DIFF
--- a/terraform/modules/cloudrun/main.tf
+++ b/terraform/modules/cloudrun/main.tf
@@ -1,18 +1,15 @@
 locals {
-  service_account_id = regexreplace(
+  service_account_id = trim(
     substr("dify-${var.workspace_suffix}-sa", 0, min(30, length("dify-${var.workspace_suffix}-sa"))),
-    "-+$",
-    ""
+    "-"
   )
-  dify_service_name = regexreplace(
+  dify_service_name = trim(
     substr("dify-${var.workspace_suffix}-service", 0, min(63, length("dify-${var.workspace_suffix}-service"))),
-    "-+$",
-    ""
+    "-"
   )
-  dify_sandbox_name = regexreplace(
+  dify_sandbox_name = trim(
     substr("dify-${var.workspace_suffix}-sandbox", 0, min(63, length("dify-${var.workspace_suffix}-sandbox"))),
-    "-+$",
-    ""
+    "-"
   )
 }
 

--- a/terraform/modules/cloudsql/main.tf
+++ b/terraform/modules/cloudsql/main.tf
@@ -1,13 +1,11 @@
 locals {
-  private_ip_range_name = regexreplace(
+  private_ip_range_name = trim(
     substr("dify-${var.workspace_suffix}-private-ip-range", 0, min(63, length("dify-${var.workspace_suffix}-private-ip-range"))),
-    "-+$",
-    ""
+    "-"
   )
-  sql_instance_name = regexreplace(
+  sql_instance_name = trim(
     substr("dify-${var.workspace_suffix}-postgres", 0, min(98, length("dify-${var.workspace_suffix}-postgres"))),
-    "-+$",
-    ""
+    "-"
   )
 }
 

--- a/terraform/modules/filestore/main.tf
+++ b/terraform/modules/filestore/main.tf
@@ -1,8 +1,7 @@
 locals {
-  filestore_name = regexreplace(
+  filestore_name = trim(
     substr("dify-${var.workspace_suffix}-filestore", 0, min(63, length("dify-${var.workspace_suffix}-filestore"))),
-    "-+$",
-    ""
+    "-"
   )
 }
 

--- a/terraform/modules/network/main.tf
+++ b/terraform/modules/network/main.tf
@@ -1,9 +1,24 @@
 locals {
-  vpc_name        = regexreplace(substr("dify-${var.workspace_suffix}-vpc", 0, min(63, length("dify-${var.workspace_suffix}-vpc"))), "-+$", "")
-  subnet_name     = regexreplace(substr("dify-${var.workspace_suffix}-subnet", 0, min(63, length("dify-${var.workspace_suffix}-subnet"))), "-+$", "")
-  firewall_name   = regexreplace(substr("dify-${var.workspace_suffix}-allow-http-https", 0, min(63, length("dify-${var.workspace_suffix}-allow-http-https"))), "-+$", "")
-  router_name     = regexreplace(substr("dify-${var.workspace_suffix}-nat-router", 0, min(63, length("dify-${var.workspace_suffix}-nat-router"))), "-+$", "")
-  router_nat_name = regexreplace(substr("dify-${var.workspace_suffix}-nat", 0, min(63, length("dify-${var.workspace_suffix}-nat"))), "-+$", "")
+  vpc_name = trim(
+    substr("dify-${var.workspace_suffix}-vpc", 0, min(63, length("dify-${var.workspace_suffix}-vpc"))),
+    "-"
+  )
+  subnet_name = trim(
+    substr("dify-${var.workspace_suffix}-subnet", 0, min(63, length("dify-${var.workspace_suffix}-subnet"))),
+    "-"
+  )
+  firewall_name = trim(
+    substr("dify-${var.workspace_suffix}-allow-http-https", 0, min(63, length("dify-${var.workspace_suffix}-allow-http-https"))),
+    "-"
+  )
+  router_name = trim(
+    substr("dify-${var.workspace_suffix}-nat-router", 0, min(63, length("dify-${var.workspace_suffix}-nat-router"))),
+    "-"
+  )
+  router_nat_name = trim(
+    substr("dify-${var.workspace_suffix}-nat", 0, min(63, length("dify-${var.workspace_suffix}-nat"))),
+    "-"
+  )
 }
 
 resource "google_compute_network" "dify_vpc" {

--- a/terraform/modules/redis/main.tf
+++ b/terraform/modules/redis/main.tf
@@ -1,8 +1,7 @@
 locals {
-  redis_instance_name = regexreplace(
+  redis_instance_name = trim(
     substr("dify-${var.workspace_suffix}-redis", 0, min(63, length("dify-${var.workspace_suffix}-redis"))),
-    "-+$",
-    ""
+    "-"
   )
 }
 


### PR DESCRIPTION
## Summary
- replace the workspace suffix normalization with logic that uses only Terraform 1.1 helpers and no regex functions
- update each module that previously relied on `regexreplace` so resource names are trimmed via `substr`/`trim` combinations instead
- align storage bucket sanitization with the new helper approach for consistent normalization across modules

## Testing
- ⚠️ `terraform fmt terraform/workspace/main.tf terraform/modules/cloudrun/main.tf terraform/modules/cloudsql/main.tf terraform/modules/network/main.tf terraform/modules/redis/main.tf terraform/modules/filestore/main.tf terraform/modules/storage/main.tf` *(failed: terraform binary unavailable in container and download blocked by proxy)*
- ⚠️ `terraform -chdir=terraform/workspace plan` *(not run: terraform 1.1.x binary unavailable and download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68df67a0d4748321b3f94e17bc4b996d