### PR TITLE
Enable Cloud Filestore API for workspace

### DIFF
--- a/terraform/workspace/main.tf
+++ b/terraform/workspace/main.tf
@@ -287,6 +287,7 @@ locals {
     "compute.googleapis.com",
     "servicenetworking.googleapis.com",
     "redis.googleapis.com",
+    "file.googleapis.com",
     "vpcaccess.googleapis.com",
     "run.googleapis.com",
     "storage.googleapis.com",


### PR DESCRIPTION
## Summary
- enable the Cloud Filestore API by adding file.googleapis.com to the set of required project services

## Testing
- not run (terraform CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e338027a20832180646142066bf291