### PR TITLE
Ensure Cloud Run waits for Artifact Registry provisioning

### DIFF
--- a/terraform/workspace/main.tf
+++ b/terraform/workspace/main.tf
@@ -200,7 +200,10 @@ module "cloudrun" {
   min_instance_count          = local.config.min_instance_count
   max_instance_count          = local.config.max_instance_count
 
-  depends_on = [google_project_service.enabled_services]
+  depends_on = [
+    google_project_service.enabled_services,
+    module.registry,
+  ]
 }
 
 module "cloudsql" {


### PR DESCRIPTION
## Summary
- ensure the Cloud Run module waits for the Artifact Registry module so services deploy only after repositories exist

## Testing
- not run (terraform CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e34d392ab4832186f1101ce637ec99