### PR TITLE
Allow disabling Cloud Run deletion protection

### DIFF
--- a/terraform/modules/cloudrun/main.tf
+++ b/terraform/modules/cloudrun/main.tf
@@ -48,6 +48,7 @@ resource "google_cloud_run_service_iam_binding" "public_sanbox" {
 resource "google_cloud_run_v2_service" "dify_service" {
   name     = local.dify_service_name
   location = var.region
+  deletion_protection = var.deletion_protection
   ingress  = var.cloud_run_ingress
   labels   = var.workspace_labels
   template {
@@ -409,6 +410,7 @@ resource "google_cloud_run_v2_service" "dify_service" {
 resource "google_cloud_run_v2_service" "dify_sandbox" {
   name     = local.dify_sandbox_name
   location = var.region
+  deletion_protection = var.deletion_protection
   labels   = var.workspace_labels
 
   template {

--- a/terraform/modules/cloudrun/variables.tf
+++ b/terraform/modules/cloudrun/variables.tf
@@ -93,3 +93,9 @@ variable "min_instance_count" {
 variable "max_instance_count" {
   type = number
 }
+
+variable "deletion_protection" {
+  description = "Whether to enable deletion protection on Cloud Run services."
+  type        = bool
+  default     = false
+}

--- a/terraform/workspace/main.tf
+++ b/terraform/workspace/main.tf
@@ -69,6 +69,7 @@ locals {
     vector_store                            = var.vector_store
     indexing_max_segmentation_tokens_length = var.indexing_max_segmentation_tokens_length
     cloud_run_ingress                       = var.cloud_run_ingress
+    cloud_run_deletion_protection           = var.cloud_run_deletion_protection
     plugin_daemon_key                       = var.plugin_daemon_key
     plugin_dify_inner_api_key               = var.plugin_dify_inner_api_key
     min_instance_count                      = var.min_instance_count
@@ -182,6 +183,7 @@ module "cloudrun" {
   dify_version                = local.config.dify_version
   dify_sandbox_version        = local.config.dify_sandbox_version
   cloud_run_ingress           = local.config.cloud_run_ingress
+  deletion_protection         = try(local.config.cloud_run_deletion_protection, false)
   nginx_repository_id         = local.config.nginx_repository_id
   web_repository_id           = local.config.web_repository_id
   api_repository_id           = local.config.api_repository_id
@@ -200,7 +202,10 @@ module "cloudrun" {
   min_instance_count          = local.config.min_instance_count
   max_instance_count          = local.config.max_instance_count
 
-  depends_on = [google_project_service.enabled_services]
+  depends_on = [
+    google_project_service.enabled_services,
+    module.registry,
+  ]
 }
 
 module "cloudsql" {

--- a/terraform/workspace/variables.tf
+++ b/terraform/workspace/variables.tf
@@ -23,6 +23,11 @@ variable "cloud_run_ingress" {
   default = null
 }
 
+variable "cloud_run_deletion_protection" {
+  type    = bool
+  default = null
+}
+
 variable "nginx_repository_id" {
   type    = string
   default = null


### PR DESCRIPTION
## Summary
- add a module input that controls Cloud Run service deletion protection and default it to false
- expose the new input through the workspace module so workspaces can override it if desired

## Testing
- not run (terraform CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e34d392ab4832186f1101ce637ec99