### PR TITLE
Add sandbox image build pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ This repository allows you to automatically set up Google Cloud resources using 
     sh ./docker/cloudbuild.sh <your-project-id> <your-region>
     cd terraform/workspace
     ```
-    You can also specify a version of the dify-api image.
+    You can also specify a version of the dify-api and dify-sandbox images.
     ```sh
-    sh ./docker/cloudbuild.sh <your-project-id> <your-region> <dify-api-version>
+    sh ./docker/cloudbuild.sh <your-project-id> <your-region> <dify-api-version> <dify-sandbox-version>
     ```
     If no version is specified, the latest version is used by default.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -64,9 +64,9 @@
     sh ./docker/cloudbuild.sh <your-project-id> <your-region>
     cd terraform/workspace
     ```
-    また、dify-api イメージのバージョンを指定することもできます。
+    また、dify-api と dify-sandbox イメージのバージョンを指定することもできます。
     ```sh
-    sh ./docker/cloudbuild.sh <your-project-id> <your-region> <dify-api-version>
+    sh ./docker/cloudbuild.sh <your-project-id> <your-region> <dify-api-version> <dify-sandbox-version>
     ```
     バージョンを指定しない場合、デフォルトで最新バージョンが使用されます。
 

--- a/docker/cloudbuild.sh
+++ b/docker/cloudbuild.sh
@@ -3,6 +3,7 @@
 PROJECT_ID=$1
 REGION=$2
 DIFY_API_VERSION=${3:-"latest"}
+DIFY_SANDBOX_VERSION=${4:-"latest"}
 
 # Nginx Build and Push
 pushd docker/nginx
@@ -12,4 +13,9 @@ popd
 # API Build and Push
 pushd docker/api
 gcloud builds submit --config=cloudbuild.yaml --substitutions=_REGION=$REGION,_PROJECT_ID=$PROJECT_ID,_DIFY_API_VERSION=$DIFY_API_VERSION
+popd
+
+# Sandbox Build and Push
+pushd docker/sandbox
+gcloud builds submit --config=cloudbuild.yaml --substitutions=_REGION=$REGION,_PROJECT_ID=$PROJECT_ID,_DIFY_SANDBOX_VERSION=$DIFY_SANDBOX_VERSION
 popd

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -1,0 +1,6 @@
+# syntax=docker/dockerfile:1
+
+ARG DIFY_SANDBOX_VERSION=latest
+FROM langgenius/dify-sandbox:${DIFY_SANDBOX_VERSION}
+
+LABEL maintainer="Dify on Google Cloud"

--- a/docker/sandbox/cloudbuild.yaml
+++ b/docker/sandbox/cloudbuild.yaml
@@ -1,0 +1,17 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/dify-sandbox/langgenius/dify-sandbox:${_DIFY_SANDBOX_VERSION}'
+      - '.'
+    env:
+      - 'DIFY_SANDBOX_VERSION=${_DIFY_SANDBOX_VERSION}'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/dify-sandbox/langgenius/dify-sandbox:${_DIFY_SANDBOX_VERSION}'
+
+images:
+  - '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/dify-sandbox/langgenius/dify-sandbox:${_DIFY_SANDBOX_VERSION}'

--- a/terraform/modules/registry/main.tf
+++ b/terraform/modules/registry/main.tf
@@ -37,13 +37,7 @@ resource "google_artifact_registry_repository" "sandbox_repo" {
   location      = var.region
   repository_id = var.sandbox_repository_id
   format        = "DOCKER"
-  mode          = "REMOTE_REPOSITORY"
   labels        = var.workspace_labels
-  remote_repository_config {
-    docker_repository {
-      public_repository = "DOCKER_HUB"
-    }
-  }
 }
 
 resource "google_artifact_registry_repository" "plugin_daemon_repo" {


### PR DESCRIPTION
## Summary
- add Dockerfile and Cloud Build config to mirror the dify-sandbox image into Artifact Registry
- update the Cloud Build helper script and Terraform registry module to handle the sandbox image
- document the optional sandbox image version flag in both READMEs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e35e3cc74c83218a38bbfd326d582b