### PR TITLE
Fix README instructions for Cloud Build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This repository allows you to automatically set up Google Cloud resources using 
 
 5. Build & push container images:
     ```sh
-    cd ../../..
+    cd ../..
     sh ./docker/cloudbuild.sh <your-project-id> <your-region>
     cd terraform/workspace
     ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -60,7 +60,7 @@
 
 5. コンテナイメージをビルド＆プッシュ:
     ```sh
-    cd ../../..
+    cd ../..
     sh ./docker/cloudbuild.sh <your-project-id> <your-region>
     cd terraform/workspace
     ```


### PR DESCRIPTION
## Summary
- correct the repository root path in the README instructions for running the Cloud Build helper script in both English and Japanese documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e363da34288321a2f7fcaf4c4d4b0a