### PR TITLE
Align dify API and sandbox version input

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ This repository allows you to automatically set up Google Cloud resources using 
 
 5. Build & push container images:
     ```sh
-    cd ../../..
+    cd ../..
     sh ./docker/cloudbuild.sh <your-project-id> <your-region>
     cd terraform/workspace
     ```
-    You can also specify a version of the dify-api and dify-sandbox images.
+    You can also specify a version shared by the dify-api and dify-sandbox images.
     ```sh
-    sh ./docker/cloudbuild.sh <your-project-id> <your-region> <dify-api-version> <dify-sandbox-version>
+    sh ./docker/cloudbuild.sh <your-project-id> <your-region> <dify-version>
     ```
     If no version is specified, the latest version is used by default.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -60,13 +60,13 @@
 
 5. コンテナイメージをビルド＆プッシュ:
     ```sh
-    cd ../../..
+    cd ../..
     sh ./docker/cloudbuild.sh <your-project-id> <your-region>
     cd terraform/workspace
     ```
-    また、dify-api と dify-sandbox イメージのバージョンを指定することもできます。
+    また、dify-api と dify-sandbox イメージに共通のバージョンを指定することもできます。
     ```sh
-    sh ./docker/cloudbuild.sh <your-project-id> <your-region> <dify-api-version> <dify-sandbox-version>
+    sh ./docker/cloudbuild.sh <your-project-id> <your-region> <dify-version>
     ```
     バージョンを指定しない場合、デフォルトで最新バージョンが使用されます。
 

--- a/docker/cloudbuild.sh
+++ b/docker/cloudbuild.sh
@@ -2,8 +2,7 @@
 
 PROJECT_ID=$1
 REGION=$2
-DIFY_API_VERSION=${3:-"latest"}
-DIFY_SANDBOX_VERSION=${4:-"latest"}
+DIFY_VERSION=${3:-"latest"}
 
 # Nginx Build and Push
 pushd docker/nginx
@@ -12,10 +11,10 @@ popd
 
 # API Build and Push
 pushd docker/api
-gcloud builds submit --config=cloudbuild.yaml --substitutions=_REGION=$REGION,_PROJECT_ID=$PROJECT_ID,_DIFY_API_VERSION=$DIFY_API_VERSION
+gcloud builds submit --config=cloudbuild.yaml --substitutions=_REGION=$REGION,_PROJECT_ID=$PROJECT_ID,_DIFY_API_VERSION=$DIFY_VERSION
 popd
 
 # Sandbox Build and Push
 pushd docker/sandbox
-gcloud builds submit --config=cloudbuild.yaml --substitutions=_REGION=$REGION,_PROJECT_ID=$PROJECT_ID,_DIFY_SANDBOX_VERSION=$DIFY_SANDBOX_VERSION
+gcloud builds submit --config=cloudbuild.yaml --substitutions=_REGION=$REGION,_PROJECT_ID=$PROJECT_ID,_DIFY_SANDBOX_VERSION=$DIFY_VERSION
 popd


### PR DESCRIPTION
## Summary
- update the Cloud Build helper script to accept a single dify image version that is reused for the API and sandbox builds
- document the shared version argument in both the English and Japanese READMEs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e363da34288321a2f7fcaf4c4d4b0a