### PR TITLE
Improve Cloud Build helper robustness and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,15 @@ This repository allows you to automatically set up Google Cloud resources using 
 
 5. Build & push container images:
     ```sh
-    cd ../../..
-    sh ./docker/cloudbuild.sh <your-project-id> <your-region>
+    cd ../..
+    bash ./docker/cloudbuild.sh <your-project-id> <your-region>
     cd terraform/workspace
     ```
-    You can also specify a version of the dify-api and dify-sandbox images.
+    You can also specify a version shared by the dify-api and dify-sandbox images.
     ```sh
-    sh ./docker/cloudbuild.sh <your-project-id> <your-region> <dify-api-version> <dify-sandbox-version>
+    bash ./docker/cloudbuild.sh <your-project-id> <your-region> <dify-version>
     ```
-    If no version is specified, the latest version is used by default.
+    If no version is specified, the latest version is used by default. Ensure that the `dify_version` and `dify_sandbox_version` values in your workspace configuration match the tag you build (or are also set to `latest`). Terraform will deploy the exact tag specified there.
 
 6. Terraform plan:
     ```sh

--- a/README_ja.md
+++ b/README_ja.md
@@ -60,15 +60,15 @@
 
 5. コンテナイメージをビルド＆プッシュ:
     ```sh
-    cd ../../..
-    sh ./docker/cloudbuild.sh <your-project-id> <your-region>
+    cd ../..
+    bash ./docker/cloudbuild.sh <your-project-id> <your-region>
     cd terraform/workspace
     ```
-    また、dify-api と dify-sandbox イメージのバージョンを指定することもできます。
+    また、dify-api と dify-sandbox イメージに共通のバージョンを指定することもできます。
     ```sh
-    sh ./docker/cloudbuild.sh <your-project-id> <your-region> <dify-api-version> <dify-sandbox-version>
+    bash ./docker/cloudbuild.sh <your-project-id> <your-region> <dify-version>
     ```
-    バージョンを指定しない場合、デフォルトで最新バージョンが使用されます。
+    バージョンを指定しない場合、デフォルトで最新バージョンが使用されます。Terraform はワークスペース構成に記載した `dify_version` と `dify_sandbox_version` のタグをそのまま利用するため、ビルドしたタグと同じ値（または `latest`）を設定してください。
 
 6. Terraformをプランニング:
     ```sh

--- a/docker/cloudbuild.sh
+++ b/docker/cloudbuild.sh
@@ -1,21 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <project-id> <region> [dify-version]" >&2
+  exit 1
+fi
 
 PROJECT_ID=$1
 REGION=$2
-DIFY_API_VERSION=${3:-"latest"}
-DIFY_SANDBOX_VERSION=${4:-"latest"}
+DIFY_VERSION=${3:-"latest"}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Submitting Cloud Build jobs with Dify version '${DIFY_VERSION}'" >&2
 
 # Nginx Build and Push
-pushd docker/nginx
-gcloud builds submit --config=cloudbuild.yaml --substitutions=_REGION=$REGION,_PROJECT_ID=$PROJECT_ID
-popd
+pushd "${SCRIPT_DIR}/nginx" >/dev/null
+gcloud builds submit --config=cloudbuild.yaml --substitutions=_REGION="$REGION",_PROJECT_ID="$PROJECT_ID"
+popd >/dev/null
 
 # API Build and Push
-pushd docker/api
-gcloud builds submit --config=cloudbuild.yaml --substitutions=_REGION=$REGION,_PROJECT_ID=$PROJECT_ID,_DIFY_API_VERSION=$DIFY_API_VERSION
-popd
+pushd "${SCRIPT_DIR}/api" >/dev/null
+gcloud builds submit --config=cloudbuild.yaml --substitutions=_REGION="$REGION",_PROJECT_ID="$PROJECT_ID",_DIFY_API_VERSION="$DIFY_VERSION"
+popd >/dev/null
 
 # Sandbox Build and Push
-pushd docker/sandbox
-gcloud builds submit --config=cloudbuild.yaml --substitutions=_REGION=$REGION,_PROJECT_ID=$PROJECT_ID,_DIFY_SANDBOX_VERSION=$DIFY_SANDBOX_VERSION
-popd
+pushd "${SCRIPT_DIR}/sandbox" >/dev/null
+gcloud builds submit --config=cloudbuild.yaml --substitutions=_REGION="$REGION",_PROJECT_ID="$PROJECT_ID",_DIFY_SANDBOX_VERSION="$DIFY_VERSION"
+popd >/dev/null


### PR DESCRIPTION
## Summary
- harden `docker/cloudbuild.sh` with bash-specific execution, error handling, and stable directory resolution while keeping the unified version input
- document the bash invocation and call out that Terraform expects the same image tag configured in the workspace files for the API and sandbox images in both README variants

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e363da34288321a2f7fcaf4c4d4b0a