### PR TITLE
Fix plugin daemon Cloud Run image path

### DIFF
--- a/terraform/modules/cloudrun/main.tf
+++ b/terraform/modules/cloudrun/main.tf
@@ -231,7 +231,7 @@ resource "google_cloud_run_v2_service" "dify_service" {
     }
     containers {
       name  = "dify-plugin-daemon"
-      image = "${var.region}-docker.pkg.dev/${var.project_id}/${var.plugin_daemon_repository_id}/langgenius/dify-plugin-daemon:${var.dify_plugin_daemon_version}"
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/${var.plugin_daemon_repository_id}/dify-plugin-daemon:${var.dify_plugin_daemon_version}"
       resources {
         limits = {
           cpu    = "1"


### PR DESCRIPTION
## Summary
- correct the Cloud Run container image reference for the plugin daemon to point to the repository root image without the extra namespace

## Testing
- not run (terraform CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e383a2d67c832197e38eebd44ca559