### PR TITLE
Add Cloud Build support for plugin daemon image

### DIFF
--- a/docker/cloudbuild.sh
+++ b/docker/cloudbuild.sh
@@ -3,17 +3,19 @@
 set -euo pipefail
 
 if [[ $# -lt 2 ]]; then
-  echo "Usage: $0 <project-id> <region> [dify-version]" >&2
+  echo "Usage: $0 <project-id> <region> [dify-version] [dify-plugin-daemon-version]" >&2
   exit 1
 fi
 
 PROJECT_ID=$1
 REGION=$2
 DIFY_VERSION=${3:-"latest"}
+DIFY_PLUGIN_DAEMON_VERSION=${4:-"${DIFY_VERSION}"}
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "Submitting Cloud Build jobs with Dify version '${DIFY_VERSION}'" >&2
+echo "Submitting Cloud Build jobs with Dify Plugin Daemon version '${DIFY_PLUGIN_DAEMON_VERSION}'" >&2
 
 # Nginx Build and Push
 pushd "${SCRIPT_DIR}/nginx" >/dev/null
@@ -28,4 +30,9 @@ popd >/dev/null
 # Sandbox Build and Push
 pushd "${SCRIPT_DIR}/sandbox" >/dev/null
 gcloud builds submit --config=cloudbuild.yaml --substitutions=_REGION="$REGION",_PROJECT_ID="$PROJECT_ID",_DIFY_SANDBOX_VERSION="$DIFY_VERSION"
+popd >/dev/null
+
+# Plugin Daemon Build and Push
+pushd "${SCRIPT_DIR}/dify-plugin-daemon" >/dev/null
+gcloud builds submit --config=cloudbuild.yaml --substitutions=_REGION="$REGION",_PROJECT_ID="$PROJECT_ID",_DIFY_PLUGIN_DAEMON_VERSION="$DIFY_PLUGIN_DAEMON_VERSION"
 popd >/dev/null

--- a/docker/dify-plugin-daemon/Dockerfile
+++ b/docker/dify-plugin-daemon/Dockerfile
@@ -1,0 +1,6 @@
+# syntax=docker/dockerfile:1
+ARG DIFY_PLUGIN_DAEMON_VERSION=latest
+FROM langgenius/dify-plugin-daemon:${DIFY_PLUGIN_DAEMON_VERSION}
+
+# No additional customization is required. This image simply mirrors the
+# official langgenius/dify-plugin-daemon image into Artifact Registry.

--- a/docker/dify-plugin-daemon/cloudbuild.yaml
+++ b/docker/dify-plugin-daemon/cloudbuild.yaml
@@ -1,0 +1,17 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/dify-plugin-daemon/dify-plugin-daemon:${_DIFY_PLUGIN_DAEMON_VERSION}'
+      - '--build-arg'
+      - 'DIFY_PLUGIN_DAEMON_VERSION=${_DIFY_PLUGIN_DAEMON_VERSION}'
+      - '.'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/dify-plugin-daemon/dify-plugin-daemon:${_DIFY_PLUGIN_DAEMON_VERSION}'
+
+images:
+  - '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/dify-plugin-daemon/dify-plugin-daemon:${_DIFY_PLUGIN_DAEMON_VERSION}'


### PR DESCRIPTION
## Summary
- add a Cloud Build configuration that mirrors the langgenius/dify-plugin-daemon image into Artifact Registry
- allow cloudbuild.sh to accept an optional plugin daemon version and submit the new build

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e46ab12b5c8321a18f2bef0e5e7a57